### PR TITLE
Do not make `getnameinfo` static

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -77,7 +77,7 @@ gai_strerror(int errcode)
     return buf;
 }
 
-static int
+int
 getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t hostlen, char *serv, socklen_t servlen, int flags)
 {
   void *addr;


### PR DESCRIPTION
It's declared in [netdb.h](https://github.com/espressif/esp-idf/blob/release/v4.4/components/lwip/port/esp32/include/netdb.h#L40-L43)

Without this change, there is a compilation error:

```
/home/justin/work/esp/esp-idf/mruby-esp32/components/mruby_component/mruby/build/repos/esp32/mruby-socket/src/socket.c:81:1: error: static declaration of 'getnameinfo' follows non-static declaration
 getnameinfo(const struct sockaddr *sa, socklen_t salen, char *host, socklen_t hostlen, char *serv, socklen_t servlen, int flags)
 ^~~~~~~~~~~
In file included from /home/justin/work/esp/esp-idf/mruby-esp32/components/mruby_component/mruby/build/repos/esp32/mruby-socket/src/socket.c:25:
/home/justin/work/esp/esp-idf/components/lwip/port/esp32/include/netdb.h:40:5: note: previous declaration of 'getnameinfo' was here
 int getnameinfo(const struct sockaddr *addr, socklen_t addrlen,
     ^~~~~~~~~~~
rake aborted!
```